### PR TITLE
Don't #include sys/sysctl.h for Linux

### DIFF
--- a/ipcbuf.c
+++ b/ipcbuf.c
@@ -51,8 +51,10 @@
 #include <linux/sockios.h>
 #endif
 
+#ifndef __linux
 #ifndef __sun
 #include <sys/sysctl.h>
+#endif
 #endif
 
 #include <err.h>


### PR DESCRIPTION
Recent versions of Linux (5.10? Anything with glibc > 2.30?) do not include sys/sysctl.h.